### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - 12.15.0
+  - 13.8.0
+script:
+  - yarn build


### PR DESCRIPTION
Introduce a simple Travis CI configuration which just runs `yarn build`
at the moment. Might introduce test cases and linting later.