### PR TITLE
Use better type definitions for the low level storage implementation

### DIFF
--- a/packages/varasto-storage/README.md
+++ b/packages/varasto-storage/README.md
@@ -13,21 +13,21 @@ $ npm install --save varasto-storage
 The package provides class called `Storage`, which provides an API very similar
 to [Web Storage API].
 
-Basic usage of the `Storage` class looks like this:
+Basic usage of storage looks like this:
 
 ```TypeScript
-import { Storage } from 'varasto-storage';
+import { createStorage } from 'varasto-storage';
 
-const storage = new Storage({ dir: './data' });
+const storage = createStorage({ dir: './data' });
 ```
 
-The constructor takes an optional configuration object, which supports these
+The function takes an optional configuration object, which supports these
 settings:
 
-Property   | Default value | Description
----------- | ------------- | -----------
-`dir`      | `./data`      | Directory where the items will be persisted into.
-`encoding` | `utf-8`       | Character encoding to use when items are stored onto the disk.
+| Property   | Default value | Description                                                    |
+| ---------- | ------------- | -------------------------------------------------------------- |
+| `dir`      | `./data`      | Directory where the items will be persisted into.              |
+| `encoding` | `utf-8`       | Character encoding to use when items are stored onto the disk. |
 
 If `dir` does not exist, it will be created when an item is stored into the
 storage.
@@ -35,7 +35,7 @@ storage.
 ### Storing items
 
 ```TypeScript
-setItem(key: string, value: Object): Promise<void>
+setItem(key: string, value: JsonObject): Promise<void>
 ```
 
 Attempts to store an item identified by `key`. Returned promise will fail if an
@@ -44,7 +44,7 @@ I/O error occurs while storing the item.
 ### Retrieving items
 
 ```TypeScript
-getItem(key: string): Promise<Object|undefined>
+getItem(key: string): Promise<JsonObject|undefined>
 ```
 
 Attempts to retrieve an item identified by `key`. Returned promise will either
@@ -63,4 +63,4 @@ into a boolean value which tells whether an value with the given identifier
 existed or not. The promise will fail if an I/O error occurs while removing the
 item.
 
-[Web Storage API]: https://developer.mozilla.org/en-US/docs/Web/API/Storage
+[web storage api]: https://developer.mozilla.org/en-US/docs/Web/API/Storage

--- a/packages/varasto-storage/index.ts
+++ b/packages/varasto-storage/index.ts
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import crypto from 'crypto';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
+import { JsonObject } from 'type-fest';
 
 /**
  * JSON key-value store that persists JSON objects to disk.
@@ -15,14 +15,14 @@ export type Storage = {
    *
    * The promise will fail if an I/O error occurs.
    */
-  getItem: (key: string) => Promise<Object | undefined>;
+  getItem: (key: string) => Promise<JsonObject | undefined>;
 
   /**
    * Attempts to store an item identified by `key`.
    *
    * The promise will fail if an I/O error occurs.
    */
-  setItem: (key: string, value: Object) => Promise<void>;
+  setItem: (key: string, value: JsonObject) => Promise<void>;
 
   /**
    * Attempts to remove an item identified by `key`. Returned promise will
@@ -71,10 +71,10 @@ export const createStorage = (options?: Partial<StorageOptions>): Storage => {
     });
 
   return {
-    getItem(key: string): Promise<Object | undefined> {
+    getItem(key: string): Promise<JsonObject | undefined> {
       const itemPath = getItemPath(key);
 
-      return new Promise<Object | undefined>((resolve, reject) => {
+      return new Promise<JsonObject | undefined>((resolve, reject) => {
         fs.readFile(
           itemPath,
           encoding,
@@ -107,7 +107,7 @@ export const createStorage = (options?: Partial<StorageOptions>): Storage => {
       });
     },
 
-    setItem(key: string, value: Object): Promise<void> {
+    setItem(key: string, value: JsonObject): Promise<void> {
       const itemPath = getItemPath(key);
 
       return ensureDirectoryExists()

--- a/packages/varasto-storage/index.ts
+++ b/packages/varasto-storage/index.ts
@@ -5,130 +5,153 @@ import mkdirp from 'mkdirp';
 import path from 'path';
 
 /**
+ * JSON key-value store that persists JSON objects to disk.
+ */
+export type Storage = {
+  /**
+   * Attempts to retrieve an item identified by `key`. Returned promise will
+   * resolve into the value, or `undefined` if item with the given identifier
+   * does not exist.
+   *
+   * The promise will fail if an I/O error occurs.
+   */
+  getItem: (key: string) => Promise<Object | undefined>;
+
+  /**
+   * Attempts to store an item identified by `key`.
+   *
+   * The promise will fail if an I/O error occurs.
+   */
+  setItem: (key: string, value: Object) => Promise<void>;
+
+  /**
+   * Attempts to remove an item identified by `key`. Returned promise will
+   * resolve into a boolean value which tells whether an value with the given
+   * identifier existed or not.
+   *
+   * The promise will fail if an I/O error occurs.
+   */
+  removeItem: (key: string) => Promise<boolean>;
+};
+
+/**
  * Various options that can be given to the storage instance.
  */
-export interface StorageOptions {
+export type StorageOptions = {
   /** Path to the directory where items are being stored. */
   dir: string;
   /** Character encoding to use. Defaults to UTF-8. */
   encoding: string;
-}
+};
 
-export class Storage {
-  private readonly options: StorageOptions;
-
-  public constructor(options?: Partial<StorageOptions>) {
-    this.options = {
-      dir: './data',
-      encoding: 'utf-8',
-      ...options,
-    };
-  }
-
-  public getItem(key: string): Promise<Object|undefined> {
-    const itemPath = this.getItemPath(key);
-
-    return new Promise<Object|undefined>((resolve, reject) => {
-      fs.readFile(
-        itemPath,
-        this.options.encoding,
-        (err, text) => {
-          if (err) {
-            if (err.code === 'ENOENT') {
-              resolve(undefined);
-            } else {
-              reject(err);
-            }
-            return;
-          }
-
-          try {
-            const content = JSON.parse(text);
-
-            if (content.key === key &&
-                content.value != null &&
-                typeof content.value === 'object') {
-              resolve(content.value);
-            } else {
-              resolve(undefined);
-            }
-          } catch (err) {
-            reject(err);
-            return;
-          }
-        },
-      );
+/**
+ * Constructs new storage instance.
+ *
+ * @param options Options for the created storage instance.
+ */
+export const createStorage = (options?: Partial<StorageOptions>): Storage => {
+  const dir = options?.dir ?? './data';
+  const encoding = options?.encoding ?? 'utf-8';
+  const getItemPath = (key: string): string =>
+    path.join(
+      dir,
+      `${crypto.createHash('md5').update(key).digest('hex')}.json`,
+    );
+  const ensureDirectoryExists = (): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+      fs.exists(dir, (exists) => {
+        if (exists) {
+          resolve();
+        } else {
+          mkdirp(dir)
+            .then(() => resolve())
+            .catch(reject);
+        }
+      });
     });
-  }
 
-  public setItem(key: string, value: Object): Promise<void> {
-    const itemPath = this.getItemPath(key);
+  return {
+    getItem(key: string): Promise<Object | undefined> {
+      const itemPath = getItemPath(key);
 
-    return this.ensureDirectoryExists()
-      .then(() => new Promise((resolve, reject) => {
-        const content = { key, value };
-
-        fs.writeFile(
+      return new Promise<Object | undefined>((resolve, reject) => {
+        fs.readFile(
           itemPath,
-          JSON.stringify(content),
-          this.options.encoding,
-          (err) => {
+          encoding,
+          (err, text) => {
             if (err) {
+              if (err.code === 'ENOENT') {
+                resolve(undefined);
+              } else {
+                reject(err);
+              }
+              return;
+            }
+
+            try {
+              const content = JSON.parse(text);
+
+              if (content.key === key &&
+                  content.value != null &&
+                  typeof content.value === 'object') {
+                resolve(content.value);
+              } else {
+                resolve(undefined);
+              }
+            } catch (err) {
               reject(err);
-            } else {
-              resolve();
+              return;
             }
           },
         );
-      }));
-  }
+      });
+    },
 
-  public removeItem(key: string): Promise<boolean> {
-    const itemPath = this.getItemPath(key);
+    setItem(key: string, value: Object): Promise<void> {
+      const itemPath = getItemPath(key);
 
-    return new Promise<boolean>((resolve, reject) => {
-      fs.exists(itemPath, (exists) => {
-        if (!exists) {
-          resolve(false);
-          return;
-        }
+      return ensureDirectoryExists()
+        .then(() => new Promise((resolve, reject) => {
+          const content = { key, value };
 
-        fs.unlink(itemPath, (err) => {
-          if (err) {
-            if (err.code === 'ENOENT') {
-              resolve(false);
-            } else {
-              reject(err);
-            }
-          } else {
-            resolve(true);
+          fs.writeFile(
+            itemPath,
+            JSON.stringify(content),
+            encoding,
+            (err) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            },
+          );
+        }));
+    },
+
+    removeItem(key: string): Promise<boolean> {
+      const itemPath = getItemPath(key);
+
+      return new Promise<boolean>((resolve, reject) => {
+        fs.exists(itemPath, (exists) => {
+          if (!exists) {
+            resolve(false);
+            return;
           }
+
+          fs.unlink(itemPath, (err) => {
+            if (err) {
+              if (err.code === 'ENOENT') {
+                resolve(false);
+              } else {
+                reject(err);
+              }
+            } else {
+              resolve(true);
+            }
+          });
         });
       });
-    });
+    }
   }
-
-  private getItemPath(key: string): string {
-    const hash = crypto.createHash('md5').update(key).digest('hex');
-
-    return path.join(
-      this.options.dir,
-      `${hash}.json`,
-    );
-  }
-
-  private ensureDirectoryExists(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      fs.exists(this.options.dir, (exists) => {
-        if (exists) {
-          resolve();
-          return;
-        }
-
-        mkdirp(this.options.dir)
-          .then(() => resolve())
-          .catch(reject);
-      });
-    });
-  }
-}
+};

--- a/packages/varasto-storage/package.json
+++ b/packages/varasto-storage/package.json
@@ -33,7 +33,8 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "mkdirp": "^1.0.4"
+    "mkdirp": "^1.0.4",
+    "type-fest": "^0.20.2"
   },
   "eslintConfig": {
     "extends": "../../.eslintrc.js"

--- a/packages/varasto-storage/package.json
+++ b/packages/varasto-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varasto-storage",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Persistent JSON key-value store",
   "main": "./index.js",
   "main:src": "./index.ts",

--- a/packages/varasto-storage/yarn.lock
+++ b/packages/varasto-storage/yarn.lock
@@ -28,10 +28,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/mkdirp@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
-  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+"@types/mkdirp@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.1.tgz#0930b948914a78587de35458b86c907b6e98bbf6"
+  integrity sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==
   dependencies:
     "@types/node" "*"
 
@@ -593,6 +593,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -856,15 +861,20 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.5.1:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uri-js@^4.2.2:
   version "4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6026,6 +6026,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"


### PR DESCRIPTION
Instead of using generic `Object`, use `JsonObject` from library called `type-fest` in the low level storage.