### PR TITLE
Simplify repository structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
+/packages/*/dist
+/packages/*/node_modules
 *.log
 *.tgz

--- a/packages/cache-storage/.gitignore
+++ b/packages/cache-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/cache-storage/.npmignore
+++ b/packages/cache-storage/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/cache-storage/package.json
+++ b/packages/cache-storage/package.json
@@ -11,6 +11,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/express-crud/.gitignore
+++ b/packages/express-crud/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/express-crud/.npmignore
+++ b/packages/express-crud/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/express-crud/package.json
+++ b/packages/express-crud/package.json
@@ -13,6 +13,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/fs-storage/.gitignore
+++ b/packages/fs-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/fs-storage/.npmignore
+++ b/packages/fs-storage/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/fs-storage/package.json
+++ b/packages/fs-storage/package.json
@@ -10,6 +10,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/memory-storage/.gitignore
+++ b/packages/memory-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/memory-storage/.npmignore
+++ b/packages/memory-storage/.npmignore
@@ -1,6 +1,0 @@
-/.prettierrc.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/memory-storage/package.json
+++ b/packages/memory-storage/package.json
@@ -10,6 +10,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/multi-storage/.gitignore
+++ b/packages/multi-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/multi-storage/.npmignore
+++ b/packages/multi-storage/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/multi-storage/package.json
+++ b/packages/multi-storage/package.json
@@ -11,6 +11,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/query/.gitignore
+++ b/packages/query/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/query/.npmignore
+++ b/packages/query/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -12,6 +12,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/redis-storage/.gitignore
+++ b/packages/redis-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/redis-storage/.npmignore
+++ b/packages/redis-storage/.npmignore
@@ -1,8 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/jest.setup.redis-mock.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/redis-storage/package.json
+++ b/packages/redis-storage/package.json
@@ -11,6 +11,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/remote-storage/.gitignore
+++ b/packages/remote-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/remote-storage/.npmignore
+++ b/packages/remote-storage/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/remote-storage/package.json
+++ b/packages/remote-storage/package.json
@@ -10,6 +10,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/server/.npmignore
+++ b/packages/server/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,10 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./bin",
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/storage/.gitignore
+++ b/packages/storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/storage/.npmignore
+++ b/packages/storage/.npmignore
@@ -1,6 +1,0 @@
-/.prettierrc.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,6 +7,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },

--- a/packages/web-storage/.gitignore
+++ b/packages/web-storage/.gitignore
@@ -1,4 +1,0 @@
-/dist
-/node_modules
-*.log
-*.tgz

--- a/packages/web-storage/.npmignore
+++ b/packages/web-storage/.npmignore
@@ -1,7 +1,0 @@
-/.prettierrc.js
-/jest.config.js
-/node_modules
-/src
-/tsconfig.json
-*.log
-*.tgz

--- a/packages/web-storage/package.json
+++ b/packages/web-storage/package.json
@@ -13,6 +13,9 @@
   "main": "./dist/index.js",
   "main:src": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "engines": {
     "node": ">=12.0"
   },


### PR DESCRIPTION
Use single `.gitignore` and `files` section in all `package.json` files
instead of `.npmignore` files.