### PR TITLE
Use functions instead of copypaste

### DIFF
--- a/packages/sqlite-storage/src/utils.ts
+++ b/packages/sqlite-storage/src/utils.ts
@@ -3,6 +3,19 @@ import { isValidSlug } from 'is-valid-slug';
 import { Database } from 'sqlite';
 import { JsonObject } from 'type-fest';
 
+export const validateNamespace = (namespace: string) => {
+  if (!isValidSlug(namespace)) {
+    throw new InvalidSlugError('Given namespace is not valid slug');
+  }
+};
+
+export const validateNamespaceAndKey = (namespace: string, key: string) => {
+  validateNamespace(namespace);
+  if (!isValidSlug(key)) {
+    throw new InvalidSlugError('Given key is not valid slug');
+  }
+};
+
 export const doesNamespaceExist = (
   db: Database,
   namespace: string
@@ -26,11 +39,7 @@ export const getItem = async <T extends JsonObject>(
   key: string,
   deserialize: <T extends JsonObject>(input: string) => T | undefined
 ): Promise<T | undefined> => {
-  if (!isValidSlug(namespace)) {
-    throw new InvalidSlugError('Given namespace is not valid slug');
-  } else if (!isValidSlug(key)) {
-    throw new InvalidSlugError('Given key is not valid slug');
-  }
+  validateNamespaceAndKey(namespace, key);
 
   if (await doesNamespaceExist(db, namespace)) {
     const row = await db.get(


### PR DESCRIPTION
Convert repeating `if` statements into validation functions to reduce unnecessary bloat.