### PR TITLE
Redesign SQLite storage a bit

### DIFF
--- a/packages/sqlite-storage/README.md
+++ b/packages/sqlite-storage/README.md
@@ -26,9 +26,9 @@ $ npm install --save @varasto/sqlite-storage
 
 The package provides an function called `createSqliteStorage`, which takes an
 SQLite database instance provided by [SQLite](node-sqlite) library as argument.
-The asynchronous function then returns an storage implementation that is
-capable of storing JSON objects into the database, where each value is
-identified by _namespace_ and _key_, that must be [valid URL slugs].
+The function then returns an storage implementation that is capable of storing
+JSON objects into the database, where each value is identified by _namespace_
+and _key_, that must be [valid URL slugs].
 
 [node-sqlite]: https://github.com/kriasoft/node-sqlite
 [valid url slugs]: https://ihateregex.io/expr/url-slug/
@@ -45,8 +45,15 @@ const database = await open({
   filename: './data.db',
   driver: sqlite3.Database,
 });
-const storage = await createSqliteStorage(database);
+const storage = createSqliteStorage(database);
 ```
+
+The function also takes an optional configuration object, which supports these
+settings:
+
+| Property          | Default value | Description                                                                                           |
+| ----------------- | ------------- | ----------------------------------------------------------------------------------------------------- |
+| `dropEmptyTables` | `false`       | If `true`, once an namespace is detected to be empty, it's associated table is automatically dropped. |
 
 ### Custom serializers
 
@@ -59,16 +66,7 @@ by passing them as options to the `createSqliteStorage` function.
 [json.parse]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
 
 ```TypeScript
-import { createSqliteStorage } from '@varasto/sqlite-storage';
-import { open } from 'sqlite';
-import sqlite3 from 'sqlite3';
-import { JsonObject } from 'type-fest';
-
-const database = await open({
-  filename: './data.db',
-  driver: sqlite3.Database,
-});
-const storage = await createSqliteStorage(
+const storage = createSqliteStorage(
   database,
   {
     serialize: (data: string): JsonObject => ({}),

--- a/packages/sqlite-storage/package.json
+++ b/packages/sqlite-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@varasto/sqlite-storage",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Varasto storage implementation that stores data to SQLite database",
   "license": "MIT",
   "keywords": [
@@ -42,8 +42,7 @@
   "dependencies": {
     "@varasto/storage": "^3.1.0",
     "is-valid-slug": "^1.0.0",
-    "sqlite": "^4.2.1",
-    "sqlite3": "^5.1.6"
+    "sqlite": "^4.2.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
@@ -55,6 +54,7 @@
     "jest": "^29.5.0",
     "prettier": "^2.3.2",
     "rimraf": "^4.4.1",
+    "sqlite3": "^5.1.6",
     "ts-jest": "^29.0.5",
     "typescript": "^4.3.5",
     "yarn": "^1.22.10"

--- a/packages/sqlite-storage/src/types.ts
+++ b/packages/sqlite-storage/src/types.ts
@@ -5,6 +5,13 @@ import { JsonObject } from 'type-fest';
  */
 export type SqliteStorageOptions = {
   /**
+   * If set as `true`, tables associated to namespaces will be automatically
+   * dropped once they are detected to be empty, i.e. no longer contain any
+   * entries.
+   */
+  dropEmptyTables: boolean;
+
+  /**
    * Custom serialization function used for converting JSON into text that is
    * stored to file system.
    *


### PR DESCRIPTION
Make the SQLite database as mandatory argument for the `createSqliteStorage` function so that we drop the `sqlite3` dependency and add an option that automatically drops empty tables from the database.