### PR TITLE
Add find, filter and map methods to storage class

### DIFF
--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -7,6 +7,20 @@ Type definitions for Varasto JSON key-value store.
 [npm-image]: https://img.shields.io/npm/v/@varasto/storage.svg
 [npm-url]: https://npmjs.org/package/@varasto/storage
 
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Storing items](#storing-items)
+  - [Retrieving items](#retrieving-items)
+  - [Removing items](#removing-items)
+  - [Searching for entries](#searching-for-entries)
+  - [Updating already existing item](#updating-already-existing-item)
+  - [Testing whether an item exists or not](#testing-whether-an-item-exists-or-not)
+  - [Listing keys stored in a namespace](#listing-keys-stored-in-a-namespace)
+  - [Listing values stored in a namespace](#listing-values-stored-in-a-namespace)
+  - [Listing entries stored in a namespace](#listing-entries-stored-in-a-namespace)
+  - [Filtering entries stored in a namespace](#filtering-entries-stored-in-a-namespace)
+  - [Map operation](#map-operation)
+
 ## Installation
 
 ```shell
@@ -94,6 +108,22 @@ promise will resolve into a boolean value which tells whether an value with
 the given identifier existed or not. The promise will fail if an I/O error
 occurs while removing the item.
 
+### Searching for entries
+
+```TypeScript
+find<T extends JsonObject>(
+  namespace: string,
+  callback: (value: T, key: string) => boolean
+): Promise<[string, T | undefined]>
+```
+
+Returns the first entry from specified namespace to which given callback
+function returns `true` for, or `undefined` if the callback function does not
+return `true` for any entry in the namespace.
+
+The promise will fail if an I/O error occurs, or if given namespace is not a
+valid slug.
+
 ### Updating already existing item
 
 ```TypeScript
@@ -153,3 +183,33 @@ entries<T extends JsonObject>(
 
 Lists all items stored under an namespace, with the keys they are identified
 by. The promise will fail if an I/O error occurs.
+
+### Filtering entries stored in a namespace
+
+```TypeScript
+filter<T extends JsonObject>(
+  namespace: string,
+  callback: (value: T, key: string) => boolean
+): AsyncGenerator<[string, T]>
+```
+
+Goes through all entries from the given namespace, returning ones for which
+the given callback functions returns `true` for.
+
+The promise will fail if an I/O error occurs, or if given namespace is not a
+valid slug.
+
+### Map operation
+
+```TypeScript
+map<T extends JsonObject, U extends JsonObject>(
+  namespace: string,
+  callback: (value: T, key: string) => U
+): AsyncGenerator<[string, U]>
+```
+
+Goes through all entries from the given namespace, passing them to the given
+callback function and returning whatever the callback function returned.
+
+The promise will fail if an I/O error occurs, or if given namespace is not a
+valid slug.

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@varasto/storage",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Type definitions for Varasto key-value storage",
   "license": "MIT",
   "author": "Rauli Laine <rauli.laine@iki.fi>",
@@ -45,6 +45,7 @@
     "@typescript-eslint/parser": "^4.28.3",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
+    "is-valid-slug": "^1.0.0",
     "it-all": "^1.0.6",
     "jest": "^29.7.0",
     "prettier": "^2.3.2",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,2 +1,3 @@
 export * from './errors';
 export * from './storage';
+export * from './types';

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,0 +1,22 @@
+import { JsonObject } from 'type-fest';
+
+/**
+ * Represents an entry in key-value store.
+ */
+export type Entry<T extends JsonObject> = [string, T];
+
+/**
+ * Callback function for `find` and `filter` methods in the `Storage` class.
+ */
+export type FilterCallback<T extends JsonObject> = (
+  value: T,
+  key: string
+) => boolean;
+
+/**
+ * Callback function for `map` method in the `Storage` class.
+ */
+export type MapCallback<T extends JsonObject, U extends JsonObject = T> = (
+  value: T,
+  key: string
+) => U;


### PR DESCRIPTION
Extend storage class with `find`, `filter` and `map` methods that work pretty much like the ones provided by `Array` prototype do.